### PR TITLE
Feature ETP-3903: expand printdocumentws tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,22 +50,10 @@ repositories {
 
 sourceSets {
     main {
-        java {
-            srcDirs("src")
-        }
-    }
-    test {
-        java {
-            srcDirs("src-test/src")
-        }
         resources {
-            srcDirs("src-test/resources")
+            srcDirs("etendo-resources")
         }
     }
-}
-
-def coreCompileClasspath = rootProject.configurations.compileClasspath.filter {
-    !it.path.contains('/modules/')
 }
 
 /**
@@ -73,18 +61,7 @@ def coreCompileClasspath = rootProject.configurations.compileClasspath.filter {
 * Ex: implementation "com.sun.mail:javax.mail:1.6.2"
 */
 dependencies {
-    compileOnly files(rootProject.sourceSets.main.output, coreCompileClasspath)
-    testImplementation files(rootProject.sourceSets.main.output, coreCompileClasspath)
-
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
-    testImplementation 'org.mockito:mockito-junit-jupiter:5.12.0'
-
-   if (findProject(':modules:com.smf.ws.printdocument') != null) {
-      implementation(project(':modules:com.smf.ws.printdocument'))
-   } else {
-      implementation('com.smf:ws.printdocument:3.0.0')
-   }
+   implementation('com.smf:ws.printdocument:3.0.0')
    implementation('com.etendoerp.platform:etendo-core:[26.1.0,26.2.0)') 
 
 }

--- a/build.gradle
+++ b/build.gradle
@@ -48,13 +48,47 @@ repositories {
     }
 }
 
+sourceSets {
+    main {
+        java {
+            srcDirs("src")
+        }
+    }
+    test {
+        java {
+            srcDirs("src-test/src")
+        }
+        resources {
+            srcDirs("src-test/resources")
+        }
+    }
+}
+
+def coreCompileClasspath = rootProject.configurations.compileClasspath.filter {
+    !it.path.contains('/modules/')
+}
+
 /**
 * Declare Java dependencies using 'implementation'
 * Ex: implementation "com.sun.mail:javax.mail:1.6.2"
 */
 dependencies {
+    compileOnly files(rootProject.sourceSets.main.output, coreCompileClasspath)
+    testImplementation files(rootProject.sourceSets.main.output, coreCompileClasspath)
 
-   implementation('com.smf:ws.printdocument:3.0.0')
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
+    testImplementation 'org.mockito:mockito-junit-jupiter:5.12.0'
+
+   if (findProject(':modules:com.smf.ws.printdocument') != null) {
+      implementation(project(':modules:com.smf.ws.printdocument'))
+   } else {
+      implementation('com.smf:ws.printdocument:3.0.0')
+   }
    implementation('com.etendoerp.platform:etendo-core:[26.1.0,26.2.0)') 
 
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/src-test/src/com/etendoerp/printdocumentws/PrintDocumentTest.java
+++ b/src-test/src/com/etendoerp/printdocumentws/PrintDocumentTest.java
@@ -77,6 +77,10 @@ class PrintDocumentTest {
   private static final String PARAM_PURCHASE = "purchase";
   private static final String DOC_ORD_001 = "ORD-001";
   private static final String ORG_1 = "ORG-1";
+  private static final String ORDER_PROFORMA_001 = "PRO-001";
+  private static final String SHIPMENT_VALUED_001 = "SHV-001";
+  private static final String QUOTATION_PROFORMA_001 = "QPR-001";
+  private static final String REPORT_MANAGER_FIELD = "reportManager";
 
   @Mock
   private HttpServletRequest mockRequest;
@@ -205,7 +209,7 @@ class PrintDocumentTest {
     when(mockRequest.getParameter(PARAM_INVOICE)).thenReturn(null);
     when(mockRequest.getParameter(PARAM_SHIPMENT)).thenReturn(null);
     when(mockRequest.getParameter(PARAM_QUOTATION)).thenReturn(null);
-    when(mockRequest.getParameter(PARAM_ORDER_PROFORMA)).thenReturn("PRO-001");
+    when(mockRequest.getParameter(PARAM_ORDER_PROFORMA)).thenReturn(ORDER_PROFORMA_001);
     when(mockRequest.getParameter(PARAM_SHIPMENT_VALUED)).thenReturn(null);
     when(mockRequest.getParameter(PARAM_QUOTATION_PROFORMA)).thenReturn(null);
     when(mockRequest.getParameter(PARAM_ORGANIZATION)).thenReturn(ORG_1);
@@ -217,7 +221,7 @@ class PrintDocumentTest {
 
     List<BaseOBObject> orderList = new ArrayList<>();
     orderList.add(mock(BaseOBObject.class));
-    doReturn(orderList).when(printDocument).getOrder("PRO-001", ORG_1, null);
+    doReturn(orderList).when(printDocument).getOrder(ORDER_PROFORMA_001, ORG_1, null);
     doNothing().when(printDocument).generateDocuments(mockRequest, mockResponse,
         printDocument.customDocuments, true);
     doNothing().when(printDocument).printReports(mockResponse, false);
@@ -240,7 +244,7 @@ class PrintDocumentTest {
     when(mockRequest.getParameter(PARAM_SHIPMENT)).thenReturn(null);
     when(mockRequest.getParameter(PARAM_QUOTATION)).thenReturn(null);
     when(mockRequest.getParameter(PARAM_ORDER_PROFORMA)).thenReturn(null);
-    when(mockRequest.getParameter(PARAM_SHIPMENT_VALUED)).thenReturn("SHV-001");
+    when(mockRequest.getParameter(PARAM_SHIPMENT_VALUED)).thenReturn(SHIPMENT_VALUED_001);
     when(mockRequest.getParameter(PARAM_QUOTATION_PROFORMA)).thenReturn(null);
     when(mockRequest.getParameter(PARAM_ORGANIZATION)).thenReturn(ORG_1);
     when(mockRequest.getParameter(PARAM_PURCHASE)).thenReturn(null);
@@ -251,7 +255,7 @@ class PrintDocumentTest {
 
     List<BaseOBObject> shipmentList = new ArrayList<>();
     shipmentList.add(mock(BaseOBObject.class));
-    doReturn(shipmentList).when(printDocument).getShipment("SHV-001", ORG_1, null);
+    doReturn(shipmentList).when(printDocument).getShipment(SHIPMENT_VALUED_001, ORG_1, null);
     doNothing().when(printDocument).generateDocuments(mockRequest, mockResponse,
         printDocument.customDocuments, true);
     doNothing().when(printDocument).printReports(mockResponse, false);
@@ -275,7 +279,7 @@ class PrintDocumentTest {
     when(mockRequest.getParameter(PARAM_QUOTATION)).thenReturn(null);
     when(mockRequest.getParameter(PARAM_ORDER_PROFORMA)).thenReturn(null);
     when(mockRequest.getParameter(PARAM_SHIPMENT_VALUED)).thenReturn(null);
-    when(mockRequest.getParameter(PARAM_QUOTATION_PROFORMA)).thenReturn("QPR-001");
+    when(mockRequest.getParameter(PARAM_QUOTATION_PROFORMA)).thenReturn(QUOTATION_PROFORMA_001);
     when(mockRequest.getParameter(PARAM_ORGANIZATION)).thenReturn(ORG_1);
     when(mockRequest.getParameter(PARAM_PURCHASE)).thenReturn(null);
 
@@ -285,7 +289,7 @@ class PrintDocumentTest {
 
     List<BaseOBObject> quotationList = new ArrayList<>();
     quotationList.add(mock(BaseOBObject.class));
-    doReturn(quotationList).when(printDocument).getQuotation("QPR-001", ORG_1, null);
+    doReturn(quotationList).when(printDocument).getQuotation(QUOTATION_PROFORMA_001, ORG_1, null);
     doNothing().when(printDocument).generateDocuments(mockRequest, mockResponse,
         printDocument.customDocuments, true);
     doNothing().when(printDocument).printReports(mockResponse, false);
@@ -304,7 +308,7 @@ class PrintDocumentTest {
     org.openbravo.model.common.enterprise.DocumentType mockDocType =
         mock(org.openbravo.model.common.enterprise.DocumentType.class);
     ReportManager existingManager = mock(ReportManager.class);
-    setParentField(printDocument, "reportManager", existingManager);
+    setParentField(printDocument, REPORT_MANAGER_FIELD, existingManager);
 
     ReportManager result = printDocument.getReportManager(mockRequest, mockDocType, false);
 
@@ -320,7 +324,7 @@ class PrintDocumentTest {
         mock(org.openbravo.model.common.enterprise.DocumentType.class);
     DocumentTemplate mockTemplate = mock(DocumentTemplate.class);
     ReportManager existingManager = mock(ReportManager.class);
-    setParentField(printDocument, "reportManager", existingManager);
+    setParentField(printDocument, REPORT_MANAGER_FIELD, existingManager);
     when(mockTemplate.isActive()).thenReturn(true);
     when(mockTemplate.getTemplateLocation()).thenReturn("");
     when(mockDocType.getDocumentTemplateList()).thenReturn(Collections.singletonList(mockTemplate));
@@ -339,7 +343,7 @@ class PrintDocumentTest {
         mock(org.openbravo.model.common.enterprise.DocumentType.class);
     DocumentTemplate mockTemplate = mock(DocumentTemplate.class);
     ReportManager existingManager = mock(ReportManager.class);
-    setParentField(printDocument, "reportManager", existingManager);
+    setParentField(printDocument, REPORT_MANAGER_FIELD, existingManager);
     when(mockTemplate.isActive()).thenReturn(false);
     when(mockDocType.getDocumentTemplateList()).thenReturn(Collections.singletonList(mockTemplate));
 
@@ -367,17 +371,17 @@ class PrintDocumentTest {
     when(mockRequest.getParameter(PARAM_INVOICE)).thenReturn(null);
     when(mockRequest.getParameter(PARAM_SHIPMENT)).thenReturn(null);
     when(mockRequest.getParameter(PARAM_QUOTATION)).thenReturn(null);
-    when(mockRequest.getParameter(PARAM_ORDER_PROFORMA)).thenReturn("PRO-001");
-    when(mockRequest.getParameter(PARAM_SHIPMENT_VALUED)).thenReturn("SHV-001");
+    when(mockRequest.getParameter(PARAM_ORDER_PROFORMA)).thenReturn(ORDER_PROFORMA_001);
+    when(mockRequest.getParameter(PARAM_SHIPMENT_VALUED)).thenReturn(SHIPMENT_VALUED_001);
     when(mockRequest.getParameter(PARAM_QUOTATION_PROFORMA)).thenReturn(null);
     when(mockRequest.getParameter(PARAM_ORGANIZATION)).thenReturn(ORG_1);
     when(mockRequest.getParameter(PARAM_PURCHASE)).thenReturn("true");
 
     printDocument.documents.add(baseDocument);
     doNothing().when(printDocument).fillDocuments(DOC_ORD_001, null, null, null, ORG_1, "true");
-    doReturn(Collections.singletonList(customOrder)).when(printDocument).getOrder("PRO-001", ORG_1,
+    doReturn(Collections.singletonList(customOrder)).when(printDocument).getOrder(ORDER_PROFORMA_001, ORG_1,
         "true");
-    doReturn(Collections.singletonList(customShipment)).when(printDocument).getShipment("SHV-001",
+    doReturn(Collections.singletonList(customShipment)).when(printDocument).getShipment(SHIPMENT_VALUED_001,
         ORG_1, "true");
     doNothing().when(printDocument).generateDocuments(any(HttpServletRequest.class),
         any(HttpServletResponse.class), any(), any(Boolean.class));
@@ -401,25 +405,25 @@ class PrintDocumentTest {
     when(mockRequest.getParameter(PARAM_INVOICE)).thenReturn(null);
     when(mockRequest.getParameter(PARAM_SHIPMENT)).thenReturn(null);
     when(mockRequest.getParameter(PARAM_QUOTATION)).thenReturn(null);
-    when(mockRequest.getParameter(PARAM_ORDER_PROFORMA)).thenReturn("PRO-001");
-    when(mockRequest.getParameter(PARAM_SHIPMENT_VALUED)).thenReturn("SHV-001");
-    when(mockRequest.getParameter(PARAM_QUOTATION_PROFORMA)).thenReturn("QPR-001");
+    when(mockRequest.getParameter(PARAM_ORDER_PROFORMA)).thenReturn(ORDER_PROFORMA_001);
+    when(mockRequest.getParameter(PARAM_SHIPMENT_VALUED)).thenReturn(SHIPMENT_VALUED_001);
+    when(mockRequest.getParameter(PARAM_QUOTATION_PROFORMA)).thenReturn(QUOTATION_PROFORMA_001);
     when(mockRequest.getParameter(PARAM_ORGANIZATION)).thenReturn(ORG_1);
     when(mockRequest.getParameter(PARAM_PURCHASE)).thenReturn(null);
 
     doNothing().when(printDocument).fillDocuments(nullable(String.class), nullable(String.class),
         nullable(String.class), nullable(String.class), nullable(String.class),
         nullable(String.class));
-    doReturn(Collections.emptyList()).when(printDocument).getOrder("PRO-001", ORG_1, null);
-    doReturn(Collections.emptyList()).when(printDocument).getShipment("SHV-001", ORG_1, null);
-    doReturn(Collections.emptyList()).when(printDocument).getQuotation("QPR-001", ORG_1, null);
+    doReturn(Collections.emptyList()).when(printDocument).getOrder(ORDER_PROFORMA_001, ORG_1, null);
+    doReturn(Collections.emptyList()).when(printDocument).getShipment(SHIPMENT_VALUED_001, ORG_1, null);
+    doReturn(Collections.emptyList()).when(printDocument).getQuotation(QUOTATION_PROFORMA_001, ORG_1, null);
 
     OBException ex = assertThrows(OBException.class,
         () -> printDocument.doGet("", mockRequest, mockResponse));
 
-    assertTrue(ex.getMessage().contains("Proforma Invoice (Sales Order): PRO-001"));
-    assertTrue(ex.getMessage().contains("Valued Delivery Note (Customer): SHV-001"));
-    assertTrue(ex.getMessage().contains("Proforma Invoice (budget): QPR-001"));
+    assertTrue(ex.getMessage().contains("Proforma Invoice (Sales Order): " + ORDER_PROFORMA_001));
+    assertTrue(ex.getMessage().contains("Valued Delivery Note (Customer): " + SHIPMENT_VALUED_001));
+    assertTrue(ex.getMessage().contains("Proforma Invoice (budget): " + QUOTATION_PROFORMA_001));
   }
 
   @Test
@@ -477,8 +481,8 @@ class PrintDocumentTest {
       Field field = com.smf.ws.printdocument.PrintDocument.class.getDeclaredField(fieldName);
       field.setAccessible(true);
       field.set(target, value);
-    } catch (Exception e) {
-      throw new RuntimeException(e);
+    } catch (ReflectiveOperationException e) {
+      throw new TestSetupException("Unable to set parent field: " + fieldName, e);
     }
   }
 
@@ -490,8 +494,14 @@ class PrintDocumentTest {
       java.util.Collection<org.openbravo.erpCommon.utility.reporting.Report> savedReports =
           (java.util.Collection<org.openbravo.erpCommon.utility.reporting.Report>) field.get(target);
       savedReports.add(mock(org.openbravo.erpCommon.utility.reporting.Report.class));
-    } catch (Exception e) {
-      throw new RuntimeException(e);
+    } catch (ReflectiveOperationException e) {
+      throw new TestSetupException("Unable to add saved report", e);
+    }
+  }
+
+  private static class TestSetupException extends RuntimeException {
+    TestSetupException(String message, Throwable cause) {
+      super(message, cause);
     }
   }
 }

--- a/src-test/src/com/etendoerp/printdocumentws/PrintDocumentTest.java
+++ b/src-test/src/com/etendoerp/printdocumentws/PrintDocumentTest.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
@@ -34,14 +33,13 @@ import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import jakarta.servlet.ServletContext;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import jakarta.servlet.http.HttpSession;
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -50,7 +48,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
-import org.openbravo.base.ConfigParameters;
 import org.openbravo.base.structure.BaseOBObject;
 import org.openbravo.erpCommon.utility.reporting.DocumentType;
 import org.openbravo.erpCommon.utility.reporting.ReportManager;
@@ -308,7 +305,7 @@ class PrintDocumentTest {
     org.openbravo.model.common.enterprise.DocumentType mockDocType =
         mock(org.openbravo.model.common.enterprise.DocumentType.class);
     ReportManager existingManager = mock(ReportManager.class);
-    setParentField(printDocument, REPORT_MANAGER_FIELD, existingManager);
+    setParentField(printDocument, existingManager);
 
     ReportManager result = printDocument.getReportManager(mockRequest, mockDocType, false);
 
@@ -324,7 +321,7 @@ class PrintDocumentTest {
         mock(org.openbravo.model.common.enterprise.DocumentType.class);
     DocumentTemplate mockTemplate = mock(DocumentTemplate.class);
     ReportManager existingManager = mock(ReportManager.class);
-    setParentField(printDocument, REPORT_MANAGER_FIELD, existingManager);
+    setParentField(printDocument, existingManager);
     when(mockTemplate.isActive()).thenReturn(true);
     when(mockTemplate.getTemplateLocation()).thenReturn("");
     when(mockDocType.getDocumentTemplateList()).thenReturn(Collections.singletonList(mockTemplate));
@@ -343,7 +340,7 @@ class PrintDocumentTest {
         mock(org.openbravo.model.common.enterprise.DocumentType.class);
     DocumentTemplate mockTemplate = mock(DocumentTemplate.class);
     ReportManager existingManager = mock(ReportManager.class);
-    setParentField(printDocument, REPORT_MANAGER_FIELD, existingManager);
+    setParentField(printDocument, existingManager);
     when(mockTemplate.isActive()).thenReturn(false);
     when(mockDocType.getDocumentTemplateList()).thenReturn(Collections.singletonList(mockTemplate));
 
@@ -400,7 +397,7 @@ class PrintDocumentTest {
   }
 
   @Test
-  void testDoGetErrorMessageIncludesCustomDocumentNumbers() throws Exception {
+  void testDoGetErrorMessageIncludesCustomDocumentNumbers() {
     when(mockRequest.getParameter(PARAM_ORDER)).thenReturn(null);
     when(mockRequest.getParameter(PARAM_INVOICE)).thenReturn(null);
     when(mockRequest.getParameter(PARAM_SHIPMENT)).thenReturn(null);
@@ -450,8 +447,8 @@ class PrintDocumentTest {
     printDocument.doGet("", mockRequest, mockResponse);
 
     verify(printDocument).generateDocuments(mockRequest, mockResponse, printDocument.documents, false);
-    verify(printDocument, times(0)).generateDocuments(eq(mockRequest), eq(mockResponse),
-        eq(printDocument.customDocuments), eq(true));
+    verify(printDocument, times(0)).generateDocuments(mockRequest, mockResponse,
+        printDocument.customDocuments, true);
     verify(printDocument).printReports(mockResponse, false);
   }
 
@@ -476,13 +473,14 @@ class PrintDocumentTest {
     return (DocumentType) field.get(target);
   }
 
-  private static void setParentField(Object target, String fieldName, Object value) {
+  private static void setParentField(Object target, Object value) {
     try {
-      Field field = com.smf.ws.printdocument.PrintDocument.class.getDeclaredField(fieldName);
+      Field field = com.smf.ws.printdocument.PrintDocument.class.getDeclaredField(
+          PrintDocumentTest.REPORT_MANAGER_FIELD);
       field.setAccessible(true);
       field.set(target, value);
     } catch (ReflectiveOperationException e) {
-      throw new TestSetupException("Unable to set parent field: " + fieldName, e);
+      throw new TestSetupException("Unable to set parent field: " + PrintDocumentTest.REPORT_MANAGER_FIELD, e);
     }
   }
 

--- a/src-test/src/com/etendoerp/printdocumentws/PrintDocumentTest.java
+++ b/src-test/src/com/etendoerp/printdocumentws/PrintDocumentTest.java
@@ -18,38 +18,52 @@ package com.etendoerp.printdocumentws;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.openbravo.base.exception.OBException;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.openbravo.base.ConfigParameters;
 import org.openbravo.base.structure.BaseOBObject;
 import org.openbravo.erpCommon.utility.reporting.DocumentType;
+import org.openbravo.erpCommon.utility.reporting.ReportManager;
 import org.openbravo.model.common.enterprise.DocumentTemplate;
+
+import org.openbravo.base.exception.OBException;
+
 
 /**
  * Tests for {@link PrintDocument}.
  */
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class PrintDocumentTest {
 
   private static final String PARAM_ORDER = "order";
@@ -69,6 +83,12 @@ class PrintDocumentTest {
 
   @Mock
   private HttpServletResponse mockResponse;
+
+  @Mock
+  private HttpSession mockSession;
+
+  @Mock
+  private ServletContext mockServletContext;
 
   private PrintDocument printDocument;
 
@@ -283,10 +303,12 @@ class PrintDocumentTest {
   void testGetReportManagerDelegatesToSuperWhenNotCustom() {
     org.openbravo.model.common.enterprise.DocumentType mockDocType =
         mock(org.openbravo.model.common.enterprise.DocumentType.class);
+    ReportManager existingManager = mock(ReportManager.class);
+    setParentField(printDocument, "reportManager", existingManager);
 
-    doReturn(null).when(printDocument).getReportManager(mockRequest, mockDocType, false);
+    ReportManager result = printDocument.getReportManager(mockRequest, mockDocType, false);
 
-    assertNull(printDocument.getReportManager(mockRequest, mockDocType, false));
+    assertSame(existingManager, result);
   }
 
   /**
@@ -297,12 +319,15 @@ class PrintDocumentTest {
     org.openbravo.model.common.enterprise.DocumentType mockDocType =
         mock(org.openbravo.model.common.enterprise.DocumentType.class);
     DocumentTemplate mockTemplate = mock(DocumentTemplate.class);
+    ReportManager existingManager = mock(ReportManager.class);
+    setParentField(printDocument, "reportManager", existingManager);
     when(mockTemplate.isActive()).thenReturn(true);
     when(mockTemplate.getTemplateLocation()).thenReturn("");
     when(mockDocType.getDocumentTemplateList()).thenReturn(Collections.singletonList(mockTemplate));
 
-    assertThrows(NullPointerException.class,
-        () -> printDocument.getReportManager(mockRequest, mockDocType, true));
+    ReportManager result = printDocument.getReportManager(mockRequest, mockDocType, true);
+
+    assertSame(existingManager, result);
   }
 
   /**
@@ -313,11 +338,14 @@ class PrintDocumentTest {
     org.openbravo.model.common.enterprise.DocumentType mockDocType =
         mock(org.openbravo.model.common.enterprise.DocumentType.class);
     DocumentTemplate mockTemplate = mock(DocumentTemplate.class);
+    ReportManager existingManager = mock(ReportManager.class);
+    setParentField(printDocument, "reportManager", existingManager);
     when(mockTemplate.isActive()).thenReturn(false);
     when(mockDocType.getDocumentTemplateList()).thenReturn(Collections.singletonList(mockTemplate));
 
-    assertThrows(NullPointerException.class,
-        () -> printDocument.getReportManager(mockRequest, mockDocType, true));
+    ReportManager result = printDocument.getReportManager(mockRequest, mockDocType, true);
+
+    assertSame(existingManager, result);
   }
 
   /**
@@ -329,9 +357,141 @@ class PrintDocumentTest {
     assertTrue(printDocument.customDocuments.isEmpty());
   }
 
+  @Test
+  void testDoGetGeneratesBaseAndCustomDocumentsAndPrintsAsMultiReport() throws Exception {
+    BaseOBObject baseDocument = mock(BaseOBObject.class);
+    BaseOBObject customOrder = mock(BaseOBObject.class);
+    BaseOBObject customShipment = mock(BaseOBObject.class);
+
+    when(mockRequest.getParameter(PARAM_ORDER)).thenReturn(DOC_ORD_001);
+    when(mockRequest.getParameter(PARAM_INVOICE)).thenReturn(null);
+    when(mockRequest.getParameter(PARAM_SHIPMENT)).thenReturn(null);
+    when(mockRequest.getParameter(PARAM_QUOTATION)).thenReturn(null);
+    when(mockRequest.getParameter(PARAM_ORDER_PROFORMA)).thenReturn("PRO-001");
+    when(mockRequest.getParameter(PARAM_SHIPMENT_VALUED)).thenReturn("SHV-001");
+    when(mockRequest.getParameter(PARAM_QUOTATION_PROFORMA)).thenReturn(null);
+    when(mockRequest.getParameter(PARAM_ORGANIZATION)).thenReturn(ORG_1);
+    when(mockRequest.getParameter(PARAM_PURCHASE)).thenReturn("true");
+
+    printDocument.documents.add(baseDocument);
+    doNothing().when(printDocument).fillDocuments(DOC_ORD_001, null, null, null, ORG_1, "true");
+    doReturn(Collections.singletonList(customOrder)).when(printDocument).getOrder("PRO-001", ORG_1,
+        "true");
+    doReturn(Collections.singletonList(customShipment)).when(printDocument).getShipment("SHV-001",
+        ORG_1, "true");
+    doNothing().when(printDocument).generateDocuments(any(HttpServletRequest.class),
+        any(HttpServletResponse.class), any(), any(Boolean.class));
+    doNothing().when(printDocument).printReports(mockResponse, true);
+    addSavedReport(printDocument);
+    addSavedReport(printDocument);
+
+    printDocument.doGet("", mockRequest, mockResponse);
+
+    verify(printDocument).generateDocuments(mockRequest, mockResponse, printDocument.documents, false);
+    verify(printDocument).generateDocuments(mockRequest, mockResponse, printDocument.customDocuments,
+        true);
+    verify(printDocument).printReports(mockResponse, true);
+    assertEquals(2, printDocument.customDocuments.size());
+    assertEquals(DocumentType.SHIPMENT, getDocumentType(printDocument));
+  }
+
+  @Test
+  void testDoGetErrorMessageIncludesCustomDocumentNumbers() throws Exception {
+    when(mockRequest.getParameter(PARAM_ORDER)).thenReturn(null);
+    when(mockRequest.getParameter(PARAM_INVOICE)).thenReturn(null);
+    when(mockRequest.getParameter(PARAM_SHIPMENT)).thenReturn(null);
+    when(mockRequest.getParameter(PARAM_QUOTATION)).thenReturn(null);
+    when(mockRequest.getParameter(PARAM_ORDER_PROFORMA)).thenReturn("PRO-001");
+    when(mockRequest.getParameter(PARAM_SHIPMENT_VALUED)).thenReturn("SHV-001");
+    when(mockRequest.getParameter(PARAM_QUOTATION_PROFORMA)).thenReturn("QPR-001");
+    when(mockRequest.getParameter(PARAM_ORGANIZATION)).thenReturn(ORG_1);
+    when(mockRequest.getParameter(PARAM_PURCHASE)).thenReturn(null);
+
+    doNothing().when(printDocument).fillDocuments(nullable(String.class), nullable(String.class),
+        nullable(String.class), nullable(String.class), nullable(String.class),
+        nullable(String.class));
+    doReturn(Collections.emptyList()).when(printDocument).getOrder("PRO-001", ORG_1, null);
+    doReturn(Collections.emptyList()).when(printDocument).getShipment("SHV-001", ORG_1, null);
+    doReturn(Collections.emptyList()).when(printDocument).getQuotation("QPR-001", ORG_1, null);
+
+    OBException ex = assertThrows(OBException.class,
+        () -> printDocument.doGet("", mockRequest, mockResponse));
+
+    assertTrue(ex.getMessage().contains("Proforma Invoice (Sales Order): PRO-001"));
+    assertTrue(ex.getMessage().contains("Valued Delivery Note (Customer): SHV-001"));
+    assertTrue(ex.getMessage().contains("Proforma Invoice (budget): QPR-001"));
+  }
+
+  @Test
+  void testDoGetPrintsSingleReportWhenOnlyBaseDocumentsExist() throws Exception {
+    BaseOBObject baseDocument = mock(BaseOBObject.class);
+
+    when(mockRequest.getParameter(PARAM_ORDER)).thenReturn(DOC_ORD_001);
+    when(mockRequest.getParameter(PARAM_INVOICE)).thenReturn(null);
+    when(mockRequest.getParameter(PARAM_SHIPMENT)).thenReturn(null);
+    when(mockRequest.getParameter(PARAM_QUOTATION)).thenReturn(null);
+    when(mockRequest.getParameter(PARAM_ORDER_PROFORMA)).thenReturn(null);
+    when(mockRequest.getParameter(PARAM_SHIPMENT_VALUED)).thenReturn(null);
+    when(mockRequest.getParameter(PARAM_QUOTATION_PROFORMA)).thenReturn(null);
+    when(mockRequest.getParameter(PARAM_ORGANIZATION)).thenReturn(ORG_1);
+    when(mockRequest.getParameter(PARAM_PURCHASE)).thenReturn(null);
+
+    printDocument.documents.add(baseDocument);
+    doNothing().when(printDocument).fillDocuments(DOC_ORD_001, null, null, null, ORG_1, null);
+    doNothing().when(printDocument).generateDocuments(mockRequest, mockResponse, printDocument.documents,
+        false);
+    doNothing().when(printDocument).printReports(mockResponse, false);
+    addSavedReport(printDocument);
+
+    printDocument.doGet("", mockRequest, mockResponse);
+
+    verify(printDocument).generateDocuments(mockRequest, mockResponse, printDocument.documents, false);
+    verify(printDocument, times(0)).generateDocuments(eq(mockRequest), eq(mockResponse),
+        eq(printDocument.customDocuments), eq(true));
+    verify(printDocument).printReports(mockResponse, false);
+  }
+
+  @Test
+  void testGetReportManagerThrowsWhenCustomTemplateNeedsServletConfiguration() {
+    org.openbravo.model.common.enterprise.DocumentType mockDocType =
+        mock(org.openbravo.model.common.enterprise.DocumentType.class);
+    DocumentTemplate mockTemplate = mock(DocumentTemplate.class);
+
+    when(mockTemplate.isActive()).thenReturn(true);
+    when(mockTemplate.getTemplateLocation()).thenReturn("@basedesign@/custom.jrxml");
+    when(mockDocType.getDocumentTemplateList()).thenReturn(Collections.singletonList(mockTemplate));
+    when(mockRequest.getSession()).thenReturn(mockSession);
+    when(mockSession.getServletContext()).thenReturn(mockServletContext);
+
+    assertThrows(Exception.class, () -> printDocument.getReportManager(mockRequest, mockDocType, true));
+  }
+
   private static DocumentType getDocumentType(Object target) throws Exception {
     Field field = com.smf.ws.printdocument.PrintDocument.class.getDeclaredField("documentType");
     field.setAccessible(true);
     return (DocumentType) field.get(target);
+  }
+
+  private static void setParentField(Object target, String fieldName, Object value) {
+    try {
+      Field field = com.smf.ws.printdocument.PrintDocument.class.getDeclaredField(fieldName);
+      field.setAccessible(true);
+      field.set(target, value);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static void addSavedReport(PrintDocument target) {
+    try {
+      Field field = com.smf.ws.printdocument.PrintDocument.class.getDeclaredField("savedReports");
+      field.setAccessible(true);
+      @SuppressWarnings("unchecked")
+      java.util.Collection<org.openbravo.erpCommon.utility.reporting.Report> savedReports =
+          (java.util.Collection<org.openbravo.erpCommon.utility.reporting.Report>) field.get(target);
+      savedReports.add(mock(org.openbravo.erpCommon.utility.reporting.Report.class));
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/src-test/src/com/etendoerp/printdocumentws/ReportManagerCustomTest.java
+++ b/src-test/src/com/etendoerp/printdocumentws/ReportManagerCustomTest.java
@@ -116,7 +116,7 @@ class ReportManagerCustomTest {
    */
   @Test
   void testConstructorStoresAllFields() throws Exception {
-    assertEquals(mockConnectionProvider, getPrivateFieldObject("_connectionProvider"));
+    assertEquals(mockConnectionProvider, getPrivateFieldObject());
     assertEquals(REPLACE_WITH_FULL, getPrivateField("_strBaseWeb"));
     assertEquals(FTP_DIRECTORY, getPrivateField("_strAttachmentPath"));
     assertEquals(PREFIX, getPrivateField("_prefix"));
@@ -143,7 +143,7 @@ class ReportManagerCustomTest {
    */
   @Test
   void testPopulateDesignParametersIncludesDocumentId() throws Exception {
-    HashMap<String, Object> params = invokePopulateWithDefaults(DOC_123, LANG_EN_US, null);
+    HashMap<String, Object> params = invokePopulateWithDefaults(LANG_EN_US, null);
     assertEquals(DOC_123, params.get("DOCUMENT_ID"));
   }
 
@@ -154,7 +154,7 @@ class ReportManagerCustomTest {
    */
   @Test
   void testPopulateDesignParametersIncludesBaseAttach() throws Exception {
-    HashMap<String, Object> params = invokePopulateWithDefaults(DOC_123, LANG_EN_US, null);
+    HashMap<String, Object> params = invokePopulateWithDefaults(LANG_EN_US, null);
     assertEquals(FTP_DIRECTORY, params.get("BASE_ATTACH"));
   }
 
@@ -165,7 +165,7 @@ class ReportManagerCustomTest {
    */
   @Test
   void testPopulateDesignParametersIncludesBaseWeb() throws Exception {
-    HashMap<String, Object> params = invokePopulateWithDefaults(DOC_123, LANG_EN_US, null);
+    HashMap<String, Object> params = invokePopulateWithDefaults(LANG_EN_US, null);
     assertEquals(REPLACE_WITH_FULL, params.get("BASE_WEB"));
   }
 
@@ -176,7 +176,7 @@ class ReportManagerCustomTest {
    */
   @Test
   void testPopulateDesignParametersIncludesBaseDesign() throws Exception {
-    HashMap<String, Object> params = invokePopulateWithDefaults(DOC_123, LANG_EN_US, null);
+    HashMap<String, Object> params = invokePopulateWithDefaults(LANG_EN_US, null);
     assertEquals(PREFIX + "/" + DESIGN_VALUE + "/" + DEFAULT_DESIGN_VALUE, params.get("BASE_DESIGN"));
   }
 
@@ -187,7 +187,7 @@ class ReportManagerCustomTest {
    */
   @Test
   void testPopulateDesignParametersSetsIgnorePaginationFalse() throws Exception {
-    HashMap<String, Object> params = invokePopulateWithDefaults(DOC_123, LANG_EN_US, null);
+    HashMap<String, Object> params = invokePopulateWithDefaults(LANG_EN_US, null);
     assertFalse((Boolean) params.get("IS_IGNORE_PAGINATION"));
   }
 
@@ -198,7 +198,7 @@ class ReportManagerCustomTest {
    */
   @Test
   void testPopulateDesignParametersSetsLanguage() throws Exception {
-    HashMap<String, Object> params = invokePopulateWithDefaults(DOC_123, LANG_EN_US, null);
+    HashMap<String, Object> params = invokePopulateWithDefaults(LANG_EN_US, null);
     assertEquals(LANG_EN_US, params.get("LANGUAGE"));
   }
 
@@ -209,7 +209,7 @@ class ReportManagerCustomTest {
    */
   @Test
   void testPopulateDesignParametersSetsLocale() throws Exception {
-    HashMap<String, Object> params = invokePopulateWithDefaults(DOC_123, "es_ES", null);
+    HashMap<String, Object> params = invokePopulateWithDefaults("es_ES", null);
     Locale locale = (Locale) params.get("LOCALE");
     assertEquals("es", locale.getLanguage());
     assertEquals("ES", locale.getCountry());
@@ -222,7 +222,7 @@ class ReportManagerCustomTest {
    */
   @Test
   void testPopulateDesignParametersSetsNumberFormat() throws Exception {
-    HashMap<String, Object> params = invokePopulateWithDefaults(DOC_123, LANG_EN_US, null);
+    HashMap<String, Object> params = invokePopulateWithDefaults(LANG_EN_US, null);
     assertNotNull(params.get("NUMBERFORMAT"));
   }
 
@@ -238,7 +238,7 @@ class ReportManagerCustomTest {
     when(mockTemplateInfo.getShowCompanyData()).thenReturn("N");
     when(mockTemplateInfo.getHeaderMargin()).thenReturn("10");
 
-    HashMap<String, Object> params = invokePopulateWithDefaults(DOC_123, LANG_EN_US,
+    HashMap<String, Object> params = invokePopulateWithDefaults(LANG_EN_US,
         mockTemplateInfo);
 
     assertEquals("Y", params.get("SHOW_LOGO"));
@@ -253,7 +253,7 @@ class ReportManagerCustomTest {
    */
   @Test
   void testPopulateDesignParametersExcludesTemplateInfoWhenNull() throws Exception {
-    HashMap<String, Object> params = invokePopulateWithDefaults(DOC_123, LANG_EN_US, null);
+    HashMap<String, Object> params = invokePopulateWithDefaults(LANG_EN_US, null);
     assertFalse(params.containsKey("SHOW_LOGO"));
     assertFalse(params.containsKey("SHOW_COMPANYDATA"));
     assertFalse(params.containsKey("HEADER_MARGIN"));
@@ -266,7 +266,7 @@ class ReportManagerCustomTest {
    */
   @Test
   void testPopulateDesignParametersCountWithoutTemplateInfo() throws Exception {
-    HashMap<String, Object> params = invokePopulateWithDefaults(DOC_123, LANG_EN_US, null);
+    HashMap<String, Object> params = invokePopulateWithDefaults(LANG_EN_US, null);
     assertEquals(10, params.size());
   }
 
@@ -282,7 +282,7 @@ class ReportManagerCustomTest {
     when(mockTemplateInfo.getShowCompanyData()).thenReturn("N");
     when(mockTemplateInfo.getHeaderMargin()).thenReturn("10");
 
-    HashMap<String, Object> params = invokePopulateWithDefaults(DOC_123, LANG_EN_US,
+    HashMap<String, Object> params = invokePopulateWithDefaults(LANG_EN_US,
         mockTemplateInfo);
 
     assertEquals(13, params.size());
@@ -307,17 +307,19 @@ class ReportManagerCustomTest {
    * Creates mock {@link Report} and {@link VariablesSecureApp} objects and invokes
    * the private {@code populateDesignParameters} method with the given arguments.
    *
-   * @param documentId the document identifier to set on the mock report
-   * @param language the language code to set on the mock variables
-   * @param templateInfo the template info to set on the mock report, may be {@code null}
+   * @param language
+   *     the language code to set on the mock variables
+   * @param templateInfo
+   *     the template info to set on the mock report, may be {@code null}
    * @return the populated design parameters map
-   * @throws Exception if reflective invocation fails
+   * @throws Exception
+   *     if reflective invocation fails
    */
-  private HashMap<String, Object> invokePopulateWithDefaults(String documentId, String language,
+  private HashMap<String, Object> invokePopulateWithDefaults(String language,
       TemplateInfo templateInfo) throws Exception {
     Report mockReport = mock(Report.class);
     VariablesSecureApp mockVars = createMockVariables(language);
-    when(mockReport.getDocumentId()).thenReturn(documentId);
+    when(mockReport.getDocumentId()).thenReturn(ReportManagerCustomTest.DOC_123);
     when(mockReport.getTemplateInfo()).thenReturn(templateInfo);
     return invokePopulateDesignParameters(mockVars, mockReport);
   }
@@ -387,12 +389,12 @@ class ReportManagerCustomTest {
   /**
    * Retrieves a private field value as {@link Object} from the default test instance.
    *
-   * @param fieldName the name of the private field
    * @return the field value
-   * @throws Exception if reflective access fails
+   * @throws Exception
+   *     if reflective access fails
    */
-  private Object getPrivateFieldObject(String fieldName) throws Exception {
-    Field field = ReportManagerCustom.class.getDeclaredField(fieldName);
+  private Object getPrivateFieldObject() throws Exception {
+    Field field = ReportManagerCustom.class.getDeclaredField("_connectionProvider");
     field.setAccessible(true);
     return field.get(reportManagerCustom);
   }

--- a/src-test/src/com/etendoerp/printdocumentws/ReportManagerCustomTest.java
+++ b/src-test/src/com/etendoerp/printdocumentws/ReportManagerCustomTest.java
@@ -47,6 +47,15 @@ import org.openbravo.erpCommon.utility.reporting.TemplateInfo;
 @MockitoSettings(strictness = Strictness.LENIENT)
 class ReportManagerCustomTest {
 
+  /** Dedicated unchecked exception for reflective helper failures in tests. */
+  private static final class TestReflectionException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    private TestReflectionException(String message, ReflectiveOperationException cause) {
+      super(message, cause);
+    }
+  }
+
   private static final String FTP_DIRECTORY = "/tmp/ftp";
   private static final String REPLACE_WITH_FULL = "http://localhost/web";
   private static final String BASE_DESIGN_PATH = "design/";
@@ -139,10 +148,9 @@ class ReportManagerCustomTest {
   /**
    * Verifies that populateDesignParameters includes DOCUMENT_ID.
    *
-   * @throws Exception if reflective invocation fails
    */
   @Test
-  void testPopulateDesignParametersIncludesDocumentId() throws Exception {
+  void testPopulateDesignParametersIncludesDocumentId() {
     HashMap<String, Object> params = invokePopulateWithDefaults(LANG_EN_US, null);
     assertEquals(DOC_123, params.get("DOCUMENT_ID"));
   }
@@ -150,10 +158,9 @@ class ReportManagerCustomTest {
   /**
    * Verifies that populateDesignParameters includes BASE_ATTACH.
    *
-   * @throws Exception if reflective invocation fails
    */
   @Test
-  void testPopulateDesignParametersIncludesBaseAttach() throws Exception {
+  void testPopulateDesignParametersIncludesBaseAttach() {
     HashMap<String, Object> params = invokePopulateWithDefaults(LANG_EN_US, null);
     assertEquals(FTP_DIRECTORY, params.get("BASE_ATTACH"));
   }
@@ -161,10 +168,9 @@ class ReportManagerCustomTest {
   /**
    * Verifies that populateDesignParameters includes BASE_WEB.
    *
-   * @throws Exception if reflective invocation fails
    */
   @Test
-  void testPopulateDesignParametersIncludesBaseWeb() throws Exception {
+  void testPopulateDesignParametersIncludesBaseWeb() {
     HashMap<String, Object> params = invokePopulateWithDefaults(LANG_EN_US, null);
     assertEquals(REPLACE_WITH_FULL, params.get("BASE_WEB"));
   }
@@ -172,10 +178,9 @@ class ReportManagerCustomTest {
   /**
    * Verifies that populateDesignParameters includes BASE_DESIGN with correct path.
    *
-   * @throws Exception if reflective invocation fails
    */
   @Test
-  void testPopulateDesignParametersIncludesBaseDesign() throws Exception {
+  void testPopulateDesignParametersIncludesBaseDesign() {
     HashMap<String, Object> params = invokePopulateWithDefaults(LANG_EN_US, null);
     assertEquals(PREFIX + "/" + DESIGN_VALUE + "/" + DEFAULT_DESIGN_VALUE, params.get("BASE_DESIGN"));
   }
@@ -183,10 +188,9 @@ class ReportManagerCustomTest {
   /**
    * Verifies that IS_IGNORE_PAGINATION is set to false.
    *
-   * @throws Exception if reflective invocation fails
    */
   @Test
-  void testPopulateDesignParametersSetsIgnorePaginationFalse() throws Exception {
+  void testPopulateDesignParametersSetsIgnorePaginationFalse() {
     HashMap<String, Object> params = invokePopulateWithDefaults(LANG_EN_US, null);
     assertFalse((Boolean) params.get("IS_IGNORE_PAGINATION"));
   }
@@ -194,10 +198,9 @@ class ReportManagerCustomTest {
   /**
    * Verifies that LANGUAGE parameter is set from variables.
    *
-   * @throws Exception if reflective invocation fails
    */
   @Test
-  void testPopulateDesignParametersSetsLanguage() throws Exception {
+  void testPopulateDesignParametersSetsLanguage() {
     HashMap<String, Object> params = invokePopulateWithDefaults(LANG_EN_US, null);
     assertEquals(LANG_EN_US, params.get("LANGUAGE"));
   }
@@ -205,10 +208,9 @@ class ReportManagerCustomTest {
   /**
    * Verifies that LOCALE parameter is derived from language string.
    *
-   * @throws Exception if reflective invocation fails
    */
   @Test
-  void testPopulateDesignParametersSetsLocale() throws Exception {
+  void testPopulateDesignParametersSetsLocale() {
     HashMap<String, Object> params = invokePopulateWithDefaults("es_ES", null);
     Locale locale = (Locale) params.get("LOCALE");
     assertEquals("es", locale.getLanguage());
@@ -218,10 +220,9 @@ class ReportManagerCustomTest {
   /**
    * Verifies that NUMBERFORMAT parameter is created.
    *
-   * @throws Exception if reflective invocation fails
    */
   @Test
-  void testPopulateDesignParametersSetsNumberFormat() throws Exception {
+  void testPopulateDesignParametersSetsNumberFormat() {
     HashMap<String, Object> params = invokePopulateWithDefaults(LANG_EN_US, null);
     assertNotNull(params.get("NUMBERFORMAT"));
   }
@@ -229,10 +230,9 @@ class ReportManagerCustomTest {
   /**
    * Verifies that template info parameters are included when templateInfo is not null.
    *
-   * @throws Exception if reflective invocation fails
    */
   @Test
-  void testPopulateDesignParametersIncludesTemplateInfo() throws Exception {
+  void testPopulateDesignParametersIncludesTemplateInfo() {
     TemplateInfo mockTemplateInfo = mock(TemplateInfo.class);
     when(mockTemplateInfo.getShowLogo()).thenReturn("Y");
     when(mockTemplateInfo.getShowCompanyData()).thenReturn("N");
@@ -249,10 +249,9 @@ class ReportManagerCustomTest {
   /**
    * Verifies that template info parameters are absent when templateInfo is null.
    *
-   * @throws Exception if reflective invocation fails
    */
   @Test
-  void testPopulateDesignParametersExcludesTemplateInfoWhenNull() throws Exception {
+  void testPopulateDesignParametersExcludesTemplateInfoWhenNull() {
     HashMap<String, Object> params = invokePopulateWithDefaults(LANG_EN_US, null);
     assertFalse(params.containsKey("SHOW_LOGO"));
     assertFalse(params.containsKey("SHOW_COMPANYDATA"));
@@ -262,10 +261,9 @@ class ReportManagerCustomTest {
   /**
    * Verifies that the parameter map contains the expected number of entries without template info.
    *
-   * @throws Exception if reflective invocation fails
    */
   @Test
-  void testPopulateDesignParametersCountWithoutTemplateInfo() throws Exception {
+  void testPopulateDesignParametersCountWithoutTemplateInfo() {
     HashMap<String, Object> params = invokePopulateWithDefaults(LANG_EN_US, null);
     assertEquals(10, params.size());
   }
@@ -273,10 +271,9 @@ class ReportManagerCustomTest {
   /**
    * Verifies that the parameter map contains the expected number of entries with template info.
    *
-   * @throws Exception if reflective invocation fails
    */
   @Test
-  void testPopulateDesignParametersCountWithTemplateInfo() throws Exception {
+  void testPopulateDesignParametersCountWithTemplateInfo() {
     TemplateInfo mockTemplateInfo = mock(TemplateInfo.class);
     when(mockTemplateInfo.getShowLogo()).thenReturn("Y");
     when(mockTemplateInfo.getShowCompanyData()).thenReturn("N");
@@ -312,11 +309,9 @@ class ReportManagerCustomTest {
    * @param templateInfo
    *     the template info to set on the mock report, may be {@code null}
    * @return the populated design parameters map
-   * @throws Exception
-   *     if reflective invocation fails
    */
   private HashMap<String, Object> invokePopulateWithDefaults(String language,
-      TemplateInfo templateInfo) throws Exception {
+      TemplateInfo templateInfo) {
     Report mockReport = mock(Report.class);
     VariablesSecureApp mockVars = createMockVariables(language);
     when(mockReport.getDocumentId()).thenReturn(ReportManagerCustomTest.DOC_123);
@@ -350,15 +345,18 @@ class ReportManagerCustomTest {
    * @param variables the variables to pass to the method
    * @param report the report to pass to the method
    * @return the resulting design parameters map
-   * @throws Exception if reflective invocation fails
    */
   @SuppressWarnings("unchecked")
   private HashMap<String, Object> invokePopulateDesignParameters(VariablesSecureApp variables,
-      Report report) throws Exception {
-    Method method = ReportManagerCustom.class.getDeclaredMethod("populateDesignParameters",
-        VariablesSecureApp.class, Report.class);
-    method.setAccessible(true);
-    return (HashMap<String, Object>) method.invoke(reportManagerCustom, variables, report);
+      Report report) {
+    try {
+      Method method = ReportManagerCustom.class.getDeclaredMethod("populateDesignParameters",
+          VariablesSecureApp.class, Report.class);
+      method.setAccessible(true);
+      return (HashMap<String, Object>) method.invoke(reportManagerCustom, variables, report);
+    } catch (ReflectiveOperationException exception) {
+      throw new TestReflectionException("Unable to invoke populateDesignParameters", exception);
+    }
   }
 
   /**
@@ -366,9 +364,8 @@ class ReportManagerCustomTest {
    *
    * @param fieldName the name of the private field
    * @return the field value
-   * @throws Exception if reflective access fails
    */
-  private String getPrivateField(String fieldName) throws Exception {
+  private String getPrivateField(String fieldName) {
     return getPrivateField(reportManagerCustom, fieldName);
   }
 
@@ -378,24 +375,29 @@ class ReportManagerCustomTest {
    * @param instance the {@link ReportManagerCustom} instance to read from
    * @param fieldName the name of the private field
    * @return the field value
-   * @throws Exception if reflective access fails
    */
-  private String getPrivateField(ReportManagerCustom instance, String fieldName) throws Exception {
-    Field field = ReportManagerCustom.class.getDeclaredField(fieldName);
-    field.setAccessible(true);
-    return (String) field.get(instance);
+  private String getPrivateField(ReportManagerCustom instance, String fieldName) {
+    try {
+      Field field = ReportManagerCustom.class.getDeclaredField(fieldName);
+      field.setAccessible(true);
+      return (String) field.get(instance);
+    } catch (ReflectiveOperationException exception) {
+      throw new TestReflectionException("Unable to read private field '" + fieldName + "'", exception);
+    }
   }
 
   /**
    * Retrieves a private field value as {@link Object} from the default test instance.
    *
    * @return the field value
-   * @throws Exception
-   *     if reflective access fails
    */
-  private Object getPrivateFieldObject() throws Exception {
-    Field field = ReportManagerCustom.class.getDeclaredField("_connectionProvider");
-    field.setAccessible(true);
-    return field.get(reportManagerCustom);
+  private Object getPrivateFieldObject() {
+    try {
+      Field field = ReportManagerCustom.class.getDeclaredField("_connectionProvider");
+      field.setAccessible(true);
+      return field.get(reportManagerCustom);
+    } catch (ReflectiveOperationException exception) {
+      throw new TestReflectionException("Unable to read private field '_connectionProvider'", exception);
+    }
   }
 }

--- a/src-test/src/com/etendoerp/printdocumentws/ReportManagerCustomTest.java
+++ b/src-test/src/com/etendoerp/printdocumentws/ReportManagerCustomTest.java
@@ -302,6 +302,7 @@ class ReportManagerCustomTest {
         () -> reportManagerCustom.processReport(mockReport, mockVars));
   }
 
+
   /**
    * Creates mock {@link Report} and {@link VariablesSecureApp} objects and invokes
    * the private {@code populateDesignParameters} method with the given arguments.


### PR DESCRIPTION
This pull request significantly expands and improves the test coverage for the `PrintDocument` class, focusing on scenarios involving custom and base document handling, error reporting, and delegation logic for report managers. It introduces new test cases to verify the correct behavior of multi-document printing, error messages, and custom template handling. Additionally, the changes update imports to use Jakarta EE and add helpful test utilities.

Key changes include:

### Expanded Test Coverage for Document Handling

* Added tests to verify that `doGet` correctly generates both base and custom documents, prints multi-reports, and handles scenarios where only base documents exist. These tests ensure the correct invocation of document generation and report printing methods, and validate the contents of `customDocuments` and document type assignment.
* Added a test that checks error messages include custom document numbers when certain custom documents are missing, improving the reliability and clarity of error reporting.

### Improved Report Manager Delegation Logic

* Updated tests for `getReportManager` to verify that it delegates to the existing report manager instance when appropriate (e.g., when not custom, when template location is empty, or when there are no active templates), using `assertSame` instead of `assertNull` and setting up the `reportManager` field. [[1]](diffhunk://#diff-f9802848179bdb5c9f68c5852ad56009385fcf9e9dbd0b380a53bbad64107bb7R306-R311) [[2]](diffhunk://#diff-f9802848179bdb5c9f68c5852ad56009385fcf9e9dbd0b380a53bbad64107bb7R322-R330) [[3]](diffhunk://#diff-f9802848179bdb5c9f68c5852ad56009385fcf9e9dbd0b380a53bbad64107bb7R341-R348)
* Added a test to ensure that an exception is thrown when a custom template requires servlet configuration, increasing robustness for custom template scenarios.

### Test Infrastructure and Import Updates

* Updated imports to use Jakarta EE (`jakarta.servlet` and related classes), added new mock fields for `HttpSession` and `ServletContext`, and included utility methods for setting parent fields and adding saved reports in tests. [[1]](diffhunk://#diff-f9802848179bdb5c9f68c5852ad56009385fcf9e9dbd0b380a53bbad64107bb7L21-R66) [[2]](diffhunk://#diff-f9802848179bdb5c9f68c5852ad56009385fcf9e9dbd0b380a53bbad64107bb7R87-R92) [[3]](diffhunk://#diff-f9802848179bdb5c9f68c5852ad56009385fcf9e9dbd0b380a53bbad64107bb7R360-R496)

These changes collectively enhance the reliability and maintainability of the `PrintDocument` component by ensuring comprehensive test coverage for both standard and edge-case behaviors.